### PR TITLE
Kano 25 profile page does not load

### DIFF
--- a/iron-location.js
+++ b/iron-location.js
@@ -379,6 +379,15 @@ Polymer({
     if (normalizedHref[0] !== '/') {
       normalizedHref = '/' + normalizedHref;
     }
+    
+    /**
+     * Fix for iOS 10. It adds extra `/` to pathname when create a new URL()
+     */
+    var path = normalizedHref;
+    var pathHasSlashes = path.indexOf("///");
+    if (pathHasSlashes === 0) {
+      normalizedHref = path.substr(2);
+    }
 
     // If we've been configured not to handle this url... don't handle it!
     if (this._urlSpaceRegExp && !this._urlSpaceRegExp.test(normalizedHref)) {

--- a/iron-location.js
+++ b/iron-location.js
@@ -381,13 +381,10 @@ Polymer({
     }
     
     /**
-     * Fix for iOS 10. It adds extra `/` to pathname when create a new URL()
+     * Fix for iOS 10. It adds extra `//` to pathname when create a new URL()
+     * Solution => replace extra `/` in pathname
      */
-    var path = normalizedHref;
-    var pathHasSlashes = path.indexOf("///");
-    if (pathHasSlashes === 0) {
-      normalizedHref = path.substr(2);
-    }
+    normalizedHref = normalizedHref.replace(/^\/\/\//, '/');
 
     // If we've been configured not to handle this url... don't handle it!
     if (this._urlSpaceRegExp && !this._urlSpaceRegExp.test(normalizedHref)) {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "type": "git",
     "url": "git://github.com/PolymerElements/iron-location.git"
   },
-  "homepage": "https://github.com/PolymerElements/iron-location",
-  "name": "@polymer/iron-location",
+  "homepage": "https://github.com/KanoComponents/iron-location",
+  "name": "@kano/iron-location",
   "license": "BSD-3-Clause",
   "devDependencies": {
     "webmat": "^0.2.0",


### PR DESCRIPTION
Notes:
- added a fix for routing in iOS 10 (kano play/kano/world/profile pages didn't load in iOS 10.*) 
- changed a name of element